### PR TITLE
Update config to map /share

### DIFF
--- a/open-dynamic-export/config.yaml
+++ b/open-dynamic-export/config.yaml
@@ -12,6 +12,8 @@ boot: auto
 hassio_api: true
 hassio_role: default
 webui: "http://[HOST]:[PORT:3000]"
+map:
+  - share:rw
 ports:
   3000/tcp: 3000
 ports_description:


### PR DESCRIPTION
Map the /share folder from HA to the container.

Useful to transfer files specifically cert/key.pem if you did not generate them directly in the container