### PR TITLE
Add optional INFLUXDB_* options for web UI data history

### DIFF
--- a/open-dynamic-export/DOCS.md
+++ b/open-dynamic-export/DOCS.md
@@ -252,6 +252,24 @@ Logging verbosity: `trace`, `debug`, `info`, `warning`, `error`
 
 **Default:** `info`
 
+### InfluxDB (optional)
+
+The ODE web UI's data-history endpoints (`/api/data/connection`, `/api/data/generationLimit`, `/api/data/energize`, `/api/data/exportLimit`) read from InfluxDB. When `influxdb_host` is empty (the default), these endpoints return `"InfluxDB isn't available"` — this is harmless and does not affect inverter control.
+
+To enable InfluxDB logging, set `influxdb_host` to your InfluxDB host (e.g. `a0d7b954-influxdb` for the official add-on, reachable on the internal Docker network) and configure the other options as needed.
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `influxdb_host` | _(empty — disabled)_ | Hostname only, no scheme/port |
+| `influxdb_port` | `8086` | |
+| `influxdb_username` | _(empty)_ | InfluxDB v1 only |
+| `influxdb_password` | _(empty)_ | InfluxDB v1 only |
+| `influxdb_admin_token` | _(empty)_ | InfluxDB v2 admin token |
+| `influxdb_org` | `open-dynamic-export` | InfluxDB v2 |
+| `influxdb_bucket` | `data` | InfluxDB v2 |
+
+See the upstream [`.env.example`](https://github.com/longzheng/open-dynamic-export/blob/main/.env.example) for the corresponding environment variables.
+
 ---
 
 ## Troubleshooting

--- a/open-dynamic-export/config.yaml
+++ b/open-dynamic-export/config.yaml
@@ -26,6 +26,13 @@ options:
   sep2_key_path: "ode/sep2-key.pem"
   sep2_pen: "12345"
   tz: "Australia/Sydney"
+  influxdb_host: ""
+  influxdb_port: "8086"
+  influxdb_username: ""
+  influxdb_password: ""
+  influxdb_admin_token: ""
+  influxdb_org: "open-dynamic-export"
+  influxdb_bucket: "data"
   config_file: |
     {
       "setpoints": {},
@@ -63,5 +70,12 @@ schema:
   sep2_key_path: str?
   sep2_pen: str?
   tz: str?
+  influxdb_host: str?
+  influxdb_port: str?
+  influxdb_username: str?
+  influxdb_password: password?
+  influxdb_admin_token: password?
+  influxdb_org: str?
+  influxdb_bucket: str?
   config_file: str
   log_level: list(trace|debug|info|warning|error)?

--- a/open-dynamic-export/run.sh
+++ b/open-dynamic-export/run.sh
@@ -84,6 +84,26 @@ if [ -f "${ODE_CERT_DIR}/serca.pem" ]; then
   export NODE_EXTRA_CA_CERTS="${ODE_CERT_DIR}/serca.pem"
 fi
 
+# ---------------------------
+# Optional InfluxDB integration
+# ---------------------------
+# Pass through INFLUXDB_* environment variables when influxdb_host is set.
+# When unset, ODE skips InfluxDB logging (the data-history endpoints of the
+# web UI will return "InfluxDB isn't available", which is harmless).
+INFLUXDB_HOST_OPT="$(jq -r '.influxdb_host // ""' /data/options.json)"
+if [ -n "${INFLUXDB_HOST_OPT}" ]; then
+  export INFLUXDB_HOST="${INFLUXDB_HOST_OPT}"
+  export INFLUXDB_PORT="$(jq -r '.influxdb_port // "8086"' /data/options.json)"
+  export INFLUXDB_USERNAME="$(jq -r '.influxdb_username // ""' /data/options.json)"
+  export INFLUXDB_PASSWORD="$(jq -r '.influxdb_password // ""' /data/options.json)"
+  export INFLUXDB_ADMIN_TOKEN="$(jq -r '.influxdb_admin_token // ""' /data/options.json)"
+  export INFLUXDB_ORG="$(jq -r '.influxdb_org // "open-dynamic-export"' /data/options.json)"
+  export INFLUXDB_BUCKET="$(jq -r '.influxdb_bucket // "data"' /data/options.json)"
+  echo "[INFO] InfluxDB logging enabled (host=${INFLUXDB_HOST}:${INFLUXDB_PORT}, org=${INFLUXDB_ORG}, bucket=${INFLUXDB_BUCKET})"
+else
+  echo "[INFO] InfluxDB logging disabled (influxdb_host option is empty)"
+fi
+
 export NODE_ENV=production
 
 echo "[INFO] =========================================="
@@ -96,6 +116,7 @@ echo "[INFO] SEP2_CERT_FILE    : ${SEP2_CERT_FILE}"
 echo "[INFO] SEP2_KEY_FILE     : ${SEP2_KEY_FILE}"
 echo "[INFO] SEP2_PEN          : ${SEP2_PEN}"
 echo "[INFO] NODE_EXTRA_CA_CERTS: ${NODE_EXTRA_CA_CERTS:-<not set>}"
+echo "[INFO] INFLUXDB_HOST     : ${INFLUXDB_HOST:-<not set>}"
 
 cd /ode
 exec pnpm start


### PR DESCRIPTION
## Summary

Adds optional add-on options that pass through the seven `INFLUXDB_*` environment variables documented in upstream's [`.env.example`](https://github.com/longzheng/open-dynamic-export/blob/main/.env.example).

## Motivation

The add-on wrapper currently does not expose any InfluxDB configuration. Upstream ODE silently skips InfluxDB writes when `INFLUXDB_HOST` is unset, but the web UI's data-history endpoints (`/api/data/connection`, `/api/data/generationLimit`, `/api/data/energize`, `/api/data/exportLimit`) still try to read from InfluxDB and return the following stack on every request:

```
Error: InfluxDB isn't available
    at queryConnection (file:///ode/dist/helpers/influxdb.js:550:15)
    at DataController.connection (file:///ode/dist/server/controllers/dataController.js:32:16)
    ...
```

The error is harmless — inverter control, CSIP-AUS communication, and MQTT publishing all continue to work — but it makes the web UI's data-history views unusable and clutters the add-on logs whenever the UI is loaded. There is currently no way to enable InfluxDB integration without forking the add-on.

## Changes

- **`config.yaml`** — add seven new optional keys to `options` and `schema`:
  - `influxdb_host` (default `""` → disabled)
  - `influxdb_port` (default `"8086"`)
  - `influxdb_username`, `influxdb_password` (InfluxDB v1)
  - `influxdb_admin_token`, `influxdb_org`, `influxdb_bucket` (InfluxDB v2)
  - `influxdb_password` and `influxdb_admin_token` use the `password?` schema type so the HA UI masks them.
- **`run.sh`** — when `influxdb_host` is non-empty, `export` the matching `INFLUXDB_*` environment variables before launching ODE. Add a startup log line confirming whether InfluxDB logging is enabled or disabled.
- **`DOCS.md`** — add a short section under *Configuration Options* describing the new options, when to use them, and that the existing "InfluxDB isn't available" log is harmless when disabled.

## Compatibility

Fully backward-compatible. All new options default to empty/disabled, so existing installations behave identically to before. Users who want InfluxDB logging only need to set `influxdb_host` (e.g. `a0d7b954-influxdb` for the official InfluxDB add-on) plus the relevant auth fields.

## Testing

- `bash -n open-dynamic-export/run.sh` passes.
- `python3 -c "import yaml; yaml.safe_load(open('open-dynamic-export/config.yaml'))"` passes; new keys appear in both `options` and `schema`.
- Container build/runtime not yet verified end-to-end; happy to follow up with logs from a live install if useful.

## Notes

The `INFLUXDB_*` variable names, defaults, and semantics match upstream verbatim — no translation or renaming. This keeps the add-on a thin wrapper and avoids divergence if upstream adds more variables.
